### PR TITLE
Feature/wait sqs on exit

### DIFF
--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -172,11 +172,16 @@ func (p *sqsListen) listen() {
 	}
 }
 
-func (p *sqsListen) Exit() error {
+func (p *sqsListen) Stop() {
 	if atomic.LoadUint32(&p.exiting) > 0 {
-		return nil
+		return
 	}
+	log.Printf("SQS Exiting %s", p.URL)
 	atomic.AddUint32(&p.exiting, 1)
+}
+
+func (p *sqsListen) Exit() error {
+	p.Stop()
 	<-p.done
 	log.Printf("SQS EXIT %s", p.URL)
 	return nil

--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -78,6 +78,7 @@ func newSQSListen(r *reactor.Reactor, c map[string]interface{}) (*sqsListen, err
 		return nil, err
 	}
 	p.broadcastCh.Store(r, true)
+	p.pendings = make(map[string]int)
 
 	p.svc = sqs.New(sess, &aws.Config{Region: aws.String(p.Region)})
 

--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -93,7 +93,11 @@ func (p *sqsListen) AddOrUpdate(r *reactor.Reactor) {
 
 func (p *sqsListen) listen() {
 	defer func() {
-		p.done <- struct{}{}
+		p.broadcastCh.Range(func(k, v interface{}) bool {
+			p.done <- struct{}{}
+			return true
+		})
+		log.Printf("SQS EXIT %s", p.URL)
 	}()
 
 	for {
@@ -184,7 +188,6 @@ func (p *sqsListen) Stop() {
 func (p *sqsListen) Exit() error {
 	p.Stop()
 	<-p.done
-	log.Printf("SQS EXIT %s", p.URL)
 	return nil
 }
 

--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -98,6 +98,7 @@ func (p *sqsListen) listen() {
 
 	for {
 		if atomic.LoadUint32(&p.exiting) > 0 {
+			log.Printf("SQS Listener Stopped %s", p.URL)
 			tries := 0
 			for len(p.pendings) > 0 {
 				time.Sleep(time.Second)

--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -102,7 +102,7 @@ func (p *sqsListen) listen() {
 			for len(p.pendings) > 0 {
 				time.Sleep(time.Second)
 				tries++
-				if tries > 120 {
+				if tries > 120 { // Wait no more than 120 seconds, the usual max
 					break
 				}
 			}
@@ -176,8 +176,8 @@ func (p *sqsListen) Stop() {
 	if atomic.LoadUint32(&p.exiting) > 0 {
 		return
 	}
-	log.Printf("SQS Exiting %s", p.URL)
 	atomic.AddUint32(&p.exiting, 1)
+	log.Printf("SQS Input Stopping %s", p.URL)
 }
 
 func (p *sqsListen) Exit() error {

--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -160,7 +160,7 @@ func (p *sqsListen) listen() {
 				}
 				atLeastOneValid = true
 				k.(*reactor.Reactor).Ch <- m
-				p.AddPending(m)
+				p.addPending(m)
 				return true
 			})
 
@@ -204,11 +204,10 @@ func (p *sqsListen) Delete(v lib.Msg) (err error) {
 	}); err != nil {
 		log.Printf("ERROR: %s - %s", *msg.URL, err)
 	}
-	p.DelPending(v)
 	return
 }
 
-func (p *sqsListen) AddPending(m lib.Msg) {
+func (p *sqsListen) addPending(m lib.Msg) {
 	p.Lock()
 	defer p.Unlock()
 	msg, ok := m.(*Msg)
@@ -225,7 +224,8 @@ func (p *sqsListen) AddPending(m lib.Msg) {
 	p.pendings[id] = v
 }
 
-func (p *sqsListen) DelPending(m lib.Msg) {
+// Done removes the message from the pending queue.
+func (p *sqsListen) Done(m lib.Msg) {
 	p.Lock()
 	defer p.Unlock()
 	msg, ok := m.(*Msg)

--- a/inputs/sqs/sqs.go
+++ b/inputs/sqs/sqs.go
@@ -73,7 +73,6 @@ func (p *SQSPlugin) Delete(v lib.Msg) error {
 
 // Put is not needed in SQS
 func (p *SQSPlugin) Put(v lib.Msg) error {
-	p.l.DelPending(v)
 	return nil
 }
 
@@ -86,4 +85,8 @@ func (p *SQSPlugin) Exit() {
 // Stops listening
 func (p *SQSPlugin) Stop() {
 	p.l.Stop()
+}
+
+func (p *SQSPlugin) Done(v lib.Msg) {
+	p.l.Done(v)
 }

--- a/inputs/sqs/sqs.go
+++ b/inputs/sqs/sqs.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	defaultMaxNumberOfMessages = 10 // Default limit of messages can be read from SQS
-	waitTimeSeconds     = 15 // Seconds to keep open the connection to SQS
+	waitTimeSeconds            = 15 // Seconds to keep open the connection to SQS
 )
 
 // SQSPlugin struct for SQS Input plugin
@@ -73,6 +73,7 @@ func (p *SQSPlugin) Delete(v lib.Msg) error {
 
 // Put is not needed in SQS
 func (p *SQSPlugin) Put(v lib.Msg) error {
+	p.l.DelPending(v)
 	return nil
 }
 

--- a/inputs/sqs/sqs.go
+++ b/inputs/sqs/sqs.go
@@ -82,3 +82,8 @@ func (p *SQSPlugin) Exit() {
 	p.l.Exit()
 	connPool.Delete(p.URL)
 }
+
+// Stops listening
+func (p *SQSPlugin) Stop() {
+	p.l.Stop()
+}

--- a/lib/interfaces.go
+++ b/lib/interfaces.go
@@ -6,7 +6,8 @@ import "github.com/gabrielperezs/goreactor/reactorlog"
 type Input interface {
 	Put(m Msg) error
 	Delete(m Msg) error
-	Exit()
+	Stop() // Stop accepting input
+	Exit() // Exit from the loop
 }
 
 // Output is the interface for the Output plugins

--- a/lib/interfaces.go
+++ b/lib/interfaces.go
@@ -6,8 +6,9 @@ import "github.com/gabrielperezs/goreactor/reactorlog"
 type Input interface {
 	Put(m Msg) error
 	Delete(m Msg) error
-	Stop() // Stop accepting input
-	Exit() // Exit from the loop
+	Done(m Msg) // Input was processed and don't need to keep it as pending
+	Stop()      // Stop accepting input
+	Exit()      // Exit from the loop
 }
 
 // Output is the interface for the Output plugins

--- a/main.go
+++ b/main.go
@@ -84,6 +84,9 @@ func start() {
 
 func exit() {
 	for _, r := range running {
+		r.Stop() // To force to stop receiving input (SQS)
+	}
+	for _, r := range running {
 		r.Exit()
 	}
 	chMain <- true

--- a/reactor/reactor.go
+++ b/reactor/reactor.go
@@ -119,6 +119,10 @@ func (r *Reactor) Start() {
 	}
 }
 
+func (r *Reactor) Stop() {
+	r.I.Stop()
+}
+
 // Exit will close the interaction betwean the Input plugin and the Output
 // plugin, and finishing the reactor
 func (r *Reactor) Exit() {

--- a/reactor/reactor.go
+++ b/reactor/reactor.go
@@ -166,6 +166,8 @@ func (r *Reactor) deadline() {
 }
 
 func (r *Reactor) run(msg lib.Msg) {
+	defer r.I.Done(msg) // To remove this message from the pending message queue
+
 	r.deadline()
 
 	var err error
@@ -176,7 +178,6 @@ func (r *Reactor) run(msg lib.Msg) {
 
 	err = r.O.Run(rl, msg)
 	defer rl.Done(err)
-	defer r.I.Done(msg)
 
 	if err == nil {
 		if err := r.I.Delete(msg); err != nil {

--- a/reactor/reactor.go
+++ b/reactor/reactor.go
@@ -176,6 +176,7 @@ func (r *Reactor) run(msg lib.Msg) {
 
 	err = r.O.Run(rl, msg)
 	defer rl.Done(err)
+	defer r.I.Done(msg)
 
 	if err == nil {
 		if err := r.I.Delete(msg); err != nil {


### PR DESCRIPTION
It fixes that when a SQS is exiting the others are still reading messages.
Add a feature, the listener waits until all processes finish before sending the done messages.