### PR TITLE
Feature/global concurrency control

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
+require github.com/gallir/dynsemaphore v1.0.1
+
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/gabrielperezs/streamspooler v1.0.0 h1:ugRDUMBsBfp2S1ZK4ue5vfjG279LVaz
 github.com/gabrielperezs/streamspooler v1.0.0/go.mod h1:lIxIDkZaqWZJ/OtEubTSO2ijLR5rLpOd08v7CdaAWw0=
 github.com/gallir/bytebufferpool v1.0.0 h1:2nDg/Hze/DwX7AAW/9iLph6mIWDH2FP96iZQvWJoSVE=
 github.com/gallir/bytebufferpool v1.0.0/go.mod h1:EvF/25bM1AJztIQoy+py9ti+T/nOmZF21mHad2QV9p4=
+github.com/gallir/dynsemaphore v1.0.1 h1:P93a9ZzOjTBMvUUmVxqhugKuwgI385qcEWyCEA7QbSs=
+github.com/gallir/dynsemaphore v1.0.1/go.mod h1:9in45hJ6qFGIiaaU3qcXANhCakZPd1vLh7kLQBDU/fw=
 github.com/gallir/smart-relayer v8.8.6+incompatible h1:LmpHfJQEA7YAyYD6YSDIhlPzgVMCllxRWmnAw375Epo=
 github.com/gallir/smart-relayer v8.8.6+incompatible/go.mod h1:CqF474xSwX+5nKfjqf0ukBoNCiIf/qlDwLdkJdtQbXw=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/inputs/sqs/sqs.go
+++ b/inputs/sqs/sqs.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	defaultMaxNumberOfMessages = 10 // Default limit of messages can be read from SQS
-	waitTimeSeconds     = 15 // Seconds to keep open the connection to SQS
+	waitTimeSeconds            = 15 // Seconds to keep open the connection to SQS
 )
 
 // SQSPlugin struct for SQS Input plugin
@@ -80,4 +80,13 @@ func (p *SQSPlugin) Put(v lib.Msg) error {
 func (p *SQSPlugin) Exit() {
 	p.l.Exit()
 	connPool.Delete(p.URL)
+}
+
+// Stops listening
+func (p *SQSPlugin) Stop() {
+	p.l.Stop()
+}
+
+func (p *SQSPlugin) Done(v lib.Msg) {
+	p.l.Done(v)
 }

--- a/lib/interfaces.go
+++ b/lib/interfaces.go
@@ -6,7 +6,9 @@ import "github.com/gabrielperezs/goreactor/reactorlog"
 type Input interface {
 	Put(m Msg) error
 	Delete(m Msg) error
-	Exit()
+	Done(m Msg) // Input was processed and don't need to keep it as pending
+	Stop()      // Stop accepting input
+	Exit()      // Exit from the loop
 }
 
 // Output is the interface for the Output plugins

--- a/main.go
+++ b/main.go
@@ -16,13 +16,15 @@ import (
 	"github.com/gabrielperezs/goreactor/logstreams"
 	"github.com/gabrielperezs/goreactor/outputs"
 	"github.com/gabrielperezs/goreactor/reactor"
+	"github.com/gallir/dynsemaphore"
 )
 
 // Config contains all the configuration parameters needed
 // by all the plugins and filled with the TOML parser
 type Config struct {
-	LogStream interface{}
-	Reactor   []interface{}
+	MaxConcurrency int
+	LogStream      interface{}
+	Reactor        []interface{}
 }
 
 var (
@@ -61,10 +63,16 @@ func start() {
 		log.Printf("%s", err.Error())
 	}
 
+	dynsem := dynsemaphore.New(conf.MaxConcurrency)
+	if conf.MaxConcurrency != 0 {
+		log.Println("Max Concurrency set to", dynsem.GetConcurrency())
+	}
+
 	for _, r := range conf.Reactor {
 		nr := reactor.NewReactor(r)
 		nr.SetLogStreams(lg)
 		nr.SetHostname(hostname)
+		nr.SetConcurrencyControl(dynsem)
 
 		var err error
 		nr.I, err = inputs.Get(nr, r)
@@ -93,6 +101,9 @@ func exit() {
 }
 
 func restart() {
+	for _, r := range running {
+		r.Stop() // To force to stop receiving input (SQS)
+	}
 	for _, r := range running {
 		r.Exit()
 	}

--- a/main.go
+++ b/main.go
@@ -193,6 +193,11 @@ func readConfig(configFile, configDir string) (c *Config, err error) {
 		if c.LogStream == nil && configTemp.LogStream != nil {
 			c.LogStream = configTemp.LogStream
 		}
+
+		// Read first MaxConcurrency only
+		if c.MaxConcurrency == 0 && configTemp.MaxConcurrency != 0 {
+			c.MaxConcurrency = configTemp.MaxConcurrency
+		}
 	}
 	return c, nil
 }

--- a/main.go
+++ b/main.go
@@ -84,6 +84,9 @@ func start() {
 
 func exit() {
 	for _, r := range running {
+		r.Stop() // To force to stop receiving input (SQS)
+	}
+	for _, r := range running {
 		r.Exit()
 	}
 	chMain <- true

--- a/reactor/reactor.go
+++ b/reactor/reactor.go
@@ -119,6 +119,10 @@ func (r *Reactor) Start() {
 	}
 }
 
+func (r *Reactor) Stop() {
+	r.I.Stop()
+}
+
 // Exit will close the interaction betwean the Input plugin and the Output
 // plugin, and finishing the reactor
 func (r *Reactor) Exit() {
@@ -162,6 +166,8 @@ func (r *Reactor) deadline() {
 }
 
 func (r *Reactor) run(msg lib.Msg) {
+	defer r.I.Done(msg) // To remove this message from the pending message queue
+
 	r.deadline()
 
 	var err error


### PR DESCRIPTION
Added general option MaxConcurrency to control the total number of running processes. Example:

MaxConcurrency = 2
[logstream]
logstream = "stdout"

If MaxConcurrency <= 0, then it sets it to the number of CPUs.