### PR TITLE
Feature: don't block because of outstanding processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+default: build
+
+build: export CGO_ENABLED = 0
+build:
+	go env -w GOPRIVATE="github.com/Webjet/*"
+	go build -o goreactor -ldflags '-w -s'
+
+arm: export CGO_ENABLED = 0
+arm:
+	go env -w GOPRIVATE="github.com/Webjet/*"
+	env GOOS=linux GOARCH=arm64 GONOSUMDB=github.com/Webjet/engine go build -o goreactor_arm -ldflags '-w -s'
+
+clean:
+	go clean

--- a/inputs/sqs/pool.go
+++ b/inputs/sqs/pool.go
@@ -111,6 +111,7 @@ func (p *sqsListen) listen() {
 				time.Sleep(time.Second)
 				tries++
 				if tries > 120 { // Wait no more than 120 seconds, the usual max
+					log.Printf("WARNING, timeout waiting for %d pending messages", len(p.pendings))
 					break
 				}
 			}

--- a/inputs/sqs/sqs.go
+++ b/inputs/sqs/sqs.go
@@ -66,11 +66,6 @@ func NewOrGet(r *reactor.Reactor, c map[string]interface{}) (*SQSPlugin, error) 
 	return p, nil
 }
 
-// Delete message from the SQS
-func (p *SQSPlugin) Delete(v lib.Msg) error {
-	return p.l.Delete(v)
-}
-
 // Put is not needed in SQS
 func (p *SQSPlugin) Put(v lib.Msg) error {
 	return nil
@@ -87,6 +82,6 @@ func (p *SQSPlugin) Stop() {
 	p.l.Stop()
 }
 
-func (p *SQSPlugin) Done(v lib.Msg) {
-	p.l.Done(v)
+func (p *SQSPlugin) Done(v lib.Msg, status bool) {
+	p.l.Done(v, status)
 }

--- a/lib/interfaces.go
+++ b/lib/interfaces.go
@@ -4,11 +4,11 @@ import "github.com/gabrielperezs/goreactor/reactorlog"
 
 // Input is the interface for the Input plugins
 type Input interface {
-	Put(m Msg) error
-	Delete(m Msg) error
-	Done(m Msg) // Input was processed and don't need to keep it as pending
-	Stop()      // Stop accepting input
-	Exit()      // Exit from the loop
+	// Put(m Msg) error
+	//Delete(m Msg) error
+	Done(m Msg, status bool) // Input was processed and don't need to keep it as pending
+	Stop()                   // Stop accepting input
+	Exit()                   // Exit from the loop
 }
 
 // Output is the interface for the Output plugins

--- a/outputs/cmd/cmd.go
+++ b/outputs/cmd/cmd.go
@@ -166,8 +166,7 @@ func (o *Cmd) getReplacedArguments(msg lib.Msg) []string {
 // the command.
 func (o *Cmd) Run(rl reactorlog.ReactorLog, msg lib.Msg) error {
 
-	var args []string
-	args = o.getReplacedArguments(msg)
+	args := o.getReplacedArguments(msg)
 
 	logLabel := o.findReplace(msg, o.r.Label)
 	rl.SetLabel(logLabel)

--- a/reactor/reactor.go
+++ b/reactor/reactor.go
@@ -54,8 +54,8 @@ func NewReactor(icfg interface{}) *Reactor {
 
 	// There are several listeners for concurrency,
 	// better not to buffer too much to avoid to many message in travel.
-	// Leave 1 for better use of CPU but can be zero
-	r.Ch = make(chan lib.Msg, 1)
+	// Buffer reasonable values are 0 or 1
+	r.Ch = make(chan lib.Msg)
 
 	log.Printf("Reactor %d concurrent %d, delay %s", r.id, r.Concurrent, r.Delay)
 


### PR DESCRIPTION
If there was a process that took a long time to complete and its channel was full, all other processes will be blocked.

This version uses goroutines to deliver the messages and its number is limited by dynsemaphore too.