### PR TITLE
[GH Actions] Add action to create prereleases - Moved build steps to reusable workflow 

### DIFF
--- a/.github/workflows/build-asset-reusable.yaml
+++ b/.github/workflows/build-asset-reusable.yaml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ inputs.prerelease && "Prerelease" || "Release" }} ${{ github.ref }}
           draft: false
           prerelease: ${{ inputs.prerelease }}
 

--- a/.github/workflows/build-asset-reusable.yaml
+++ b/.github/workflows/build-asset-reusable.yaml
@@ -1,0 +1,68 @@
+name: Reusable - Build Asset
+
+on:
+  workflow_call:
+    inputs:
+      prerelease:
+        description: "Create release or prerelease"
+        type: boolean
+        required: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+        id: go
+
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+
+      - name: Test
+        run: go test -v ./...
+
+      - name: Build linux amd64
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o goreactor_amd64 -v .
+
+      - name: Build linux arm64
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o goreactor_arm64 -v .
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: ${{ inputs.prerelease }}
+
+      - name: Upload linux amd64
+        id: upload-release-asset-linux-amd64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: goreactor_amd64
+          asset_name: goreactor_amd64
+          asset_content_type: application/binary
+
+      - name: Upload linux arm64
+        id: upload-release-asset-linux-arm64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: goreactor_arm64
+          asset_name: goreactor_arm64
+          asset_content_type: application/binary

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,13 +1,13 @@
-name: Upload Release Asset
+name: Upload Prerelease Asset
 
 on:
   push:
     tags:
-      - "v*"
+      - "p*"
 
 jobs:
   build:
     uses: ./.github/workflows/build-asset-reusable.yaml
     secrets: inherit
     with:
-      prerelease: false
+      prerelease: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,16 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
 
       - name: Get dependencies
         run: go get -v -t -d ./...


### PR DESCRIPTION
- Create prerelease workflow which will trigger on any tag push with name starting with p (Example: p1.7.3)
- To avoid dupplicated steps, move build to reusable workflow